### PR TITLE
Handle future dates in formatDate

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,32 +6,50 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatDate(date: string) {
-  let currentDate = new Date().getTime();
+  const currentDate = new Date().getTime();
   if (!date.includes("T")) {
     date = `${date}T00:00:00`;
   }
-  let targetDate = new Date(date).getTime();
-  let timeDifference = Math.abs(currentDate - targetDate);
-  let daysAgo = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
+  const targetDate = new Date(date).getTime();
+  const diff = targetDate - currentDate;
+  const isFuture = diff > 0;
+  const daysDiff = Math.floor(Math.abs(diff) / (1000 * 60 * 60 * 24));
 
-  let fullDate = new Date(date).toLocaleString("en-us", {
+  const fullDate = new Date(date).toLocaleString("en-us", {
     month: "long",
     day: "numeric",
     year: "numeric",
   });
 
-  if (daysAgo < 1) {
+  if (daysDiff < 1) {
     return "Today";
-  } else if (daysAgo < 7) {
-    return `${fullDate} (${daysAgo}d ago)`;
-  } else if (daysAgo < 30) {
-    const weeksAgo = Math.floor(daysAgo / 7);
+  }
+
+  if (isFuture) {
+    if (daysDiff < 7) {
+      return `${fullDate} (in ${daysDiff}d)`;
+    } else if (daysDiff < 30) {
+      const weeks = Math.floor(daysDiff / 7);
+      return `${fullDate} (in ${weeks}w)`;
+    } else if (daysDiff < 365) {
+      const months = Math.floor(daysDiff / 30);
+      return `${fullDate} (in ${months}mo)`;
+    } else {
+      const years = Math.floor(daysDiff / 365);
+      return `${fullDate} (in ${years}y)`;
+    }
+  }
+
+  if (daysDiff < 7) {
+    return `${fullDate} (${daysDiff}d ago)`;
+  } else if (daysDiff < 30) {
+    const weeksAgo = Math.floor(daysDiff / 7);
     return `${fullDate} (${weeksAgo}w ago)`;
-  } else if (daysAgo < 365) {
-    const monthsAgo = Math.floor(daysAgo / 30);
+  } else if (daysDiff < 365) {
+    const monthsAgo = Math.floor(daysDiff / 30);
     return `${fullDate} (${monthsAgo}mo ago)`;
   } else {
-    const yearsAgo = Math.floor(daysAgo / 365);
+    const yearsAgo = Math.floor(daysDiff / 365);
     return `${fullDate} (${yearsAgo}y ago)`;
   }
 }


### PR DESCRIPTION
## Summary
- handle future dates in formatDate utility

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: react/no-unescaped-entities and react-hooks/exhaustive-deps)*
- `npm run build` *(fails: Failed to fetch Inter font from Google Fonts)*
- `NODE_PATH=./node_modules node -e "const {formatDate}=require('/tmp/utils.js'); console.log(formatDate('2099-01-01')); console.log(formatDate('2000-01-01'));"`


------
https://chatgpt.com/codex/tasks/task_e_68910c237af483228edae86a71acb9a1