### PR TITLE
fix: escape apostrophes in hero section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Page() {
                   delay={BLUR_FADE_DELAY}
                   className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none"
                   yOffset={8}
-                  text={`Hi, I'm ${DATA.name.split(" ")[0]} 👋`}
+                  text={`Hi, I&apos;m ${DATA.name.split(" ")[0]} 👋`}
                 />
                 <BlurFadeText
                   className="max-w-[600px] md:text-xl"
@@ -63,13 +63,13 @@ export default function Page() {
                   delay={BLUR_FADE_DELAY}
                   className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none"
                   yOffset={8}
-                  text={"Hi, I'm " + DATA.name.split(" ")[0] + " 👋"}
+                  text={"Hi, I&apos;m " + DATA.name.split(" ")[0] + " 👋"}
                 />
 
                 {/* Line 2: Constant + Animated Typewriter Text */}
                 <BlurFade delay={BLUR_FADE_DELAY + 0.02}>
                   <div className="text-lg sm:text-xl font-normal text-muted-foreground">
-                    I'm into{" "}
+                    I&apos;m into{" "}
                     <span className="font-bold underline">
                       <Typewriter
                         words={["Data Engineering", "Data Analytics", "Gen AI"]}


### PR DESCRIPTION
## Summary
- escape apostrophes in hero greeting and tagline to avoid lint warnings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68910e88d3c08322b0cdef61e18b3af1