### PR TITLE
Add href links for resume entries and fix type checks

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -90,18 +90,19 @@ interface ProjectProps {
   href?: string;
   description: string;
   dates: string;
-  technologies: string[];
+  technologies: readonly string[];
   image?: string;
   video?: string;
-  links?: {
-    icon: React.ReactNode;
-    type: string;
-    href: string;
-  }[];
+  links?:
+    | readonly {
+        icon: React.ReactNode;
+        type: string;
+        href: string;
+      }[];
 }
 
 interface CarouselProps {
-  projects: ProjectProps[];
+  projects: readonly ProjectProps[];
 }
 
 export default function ProjectCarousel({ projects }: CarouselProps) {

--- a/src/components/magicui/blur-fade.tsx
+++ b/src/components/magicui/blur-fade.tsx
@@ -3,6 +3,13 @@
 import { AnimatePresence, motion, useInView, Variants } from "framer-motion";
 import { useRef } from "react";
 
+type MarginValue = `${number}${"px" | "%"}`;
+type Margin =
+  | MarginValue
+  | `${MarginValue} ${MarginValue}`
+  | `${MarginValue} ${MarginValue} ${MarginValue}`
+  | `${MarginValue} ${MarginValue} ${MarginValue} ${MarginValue}`;
+
 interface BlurFadeProps {
   children: React.ReactNode;
   className?: string;
@@ -14,7 +21,7 @@ interface BlurFadeProps {
   delay?: number;
   yOffset?: number;
   inView?: boolean;
-  inViewMargin?: string;
+  inViewMargin?: Margin;
   blur?: string;
 }
 const BlurFade = ({

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -119,7 +119,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
   work: [
     {
       company: "Metco Scientific",
-      // href: "https://www.metcoscientific.com/",
+      href: "https://www.metcoscientific.com/",
       badges: ["Data Analytics", "ML Models", "Gen AI"],
       location: "Mumbai, India",
       title: "Data Analyst – Medical & Scientific Ops",
@@ -131,7 +131,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
     },
     {
       company: "Accenture",
-      // href: "https://www.accenture.com/",
+      href: "https://www.accenture.com/",
       badges: ["Data Engineering", "Analytics"],
       location: "India (Remote + Onsite)",
       title: "Software Engineer – Data Systems",
@@ -194,6 +194,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
   education: [
     {
       school: "Northeastern University",
+      href: "https://www.northeastern.edu/",
       degree: "Master’s in Information Systems",
       logoUrl: "/neu.png",
       start: "Sep 2023",
@@ -201,6 +202,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
     },
     {
       school: "Chandigarh Engineering College",
+      href: "https://www.cgc.edu.in/",
       degree: "B.Tech in Electronics and Communication",
       logoUrl: "/cgc.png",
       start: "Jun 2016",


### PR DESCRIPTION
## Summary
- make work and education cards clickable by providing href links
- adjust ProjectCarousel and BlurFade types to satisfy strict TypeScript checks

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689111ab853c8322b77dfe213d1bde3b