### PR TITLE
Add typed interfaces for resume data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { Typewriter } from "react-simple-typewriter";
 import { ResumeCard } from "@/components/resume-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { DATA } from "@/data/resume";
+import { DATA, type WorkItem, type EducationItem } from "@/data/resume";
 import Link from "next/link";
 import Markdown from "react-markdown";
 // for contact
@@ -127,7 +127,7 @@ export default function Page() {
             <BlurFade delay={BLUR_FADE_DELAY * 5}>
               <h2 className="text-xl font-bold">Work Experience</h2>
             </BlurFade>
-            {DATA.work.map((work, id) => (
+            {DATA.work.map((work: WorkItem, id) => (
               <BlurFade key={work.company} delay={BLUR_FADE_DELAY * 6 + id * 0.05}>
                 <ResumeCard
                   key={work.company}
@@ -149,7 +149,7 @@ export default function Page() {
             <BlurFade delay={BLUR_FADE_DELAY * 7}>
               <h2 className="text-xl font-bold">Education</h2>
             </BlurFade>
-            {DATA.education.map((education, id) => (
+            {DATA.education.map((education: EducationItem, id) => (
               <BlurFade key={education.school} delay={BLUR_FADE_DELAY * 8 + id * 0.05}>
                 <ResumeCard
                   key={education.school}

--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -90,10 +90,10 @@ interface ProjectProps {
   href?: string;
   description: string;
   dates: string;
-  technologies: string[];
+  technologies: readonly string[];
   image?: string;
   video?: string;
-  links?: {
+  links?: readonly {
     icon: React.ReactNode;
     type: string;
     href: string;
@@ -101,7 +101,7 @@ interface ProjectProps {
 }
 
 interface CarouselProps {
-  projects: ProjectProps[];
+  projects: readonly ProjectProps[];
 }
 
 export default function ProjectCarousel({ projects }: CarouselProps) {

--- a/src/components/magicui/blur-fade.tsx
+++ b/src/components/magicui/blur-fade.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { AnimatePresence, motion, useInView, Variants } from "framer-motion";
+import {
+  AnimatePresence,
+  motion,
+  useInView,
+  Variants,
+} from "framer-motion";
 import { useRef } from "react";
 
 interface BlurFadeProps {
@@ -29,7 +34,10 @@ const BlurFade = ({
   blur = "6px",
 }: BlurFadeProps) => {
   const ref = useRef(null);
-  const inViewResult = useInView(ref, { once: true, margin: inViewMargin });
+  const inViewResult = useInView(ref, {
+    once: true,
+    margin: inViewMargin as any,
+  });
   const isInView = !inView || inViewResult;
   const defaultVariants: Variants = {
     hidden: { y: yOffset, opacity: 0, filter: `blur(${blur})` },

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -1,6 +1,135 @@
 import { Icons } from "@/components/icons";
 import { HomeIcon, NotebookIcon } from "lucide-react";
 
+export interface WorkItem {
+  company: string;
+  href?: string;
+  badges?: readonly string[];
+  location: string;
+  title: string;
+  logoUrl: string;
+  start: string;
+  end?: string;
+  description?: string;
+}
+
+export interface EducationItem {
+  school: string;
+  degree: string;
+  logoUrl: string;
+  start: string;
+  end: string;
+  href?: string;
+}
+
+const work: WorkItem[] = [
+  {
+    company: "Metco Scientific",
+    // href: "https://www.metcoscientific.com/",
+    badges: ["Data Analytics", "ML Models", "Gen AI"],
+    location: "Mumbai, India",
+    title: "Data Analyst – Medical & Scientific Ops",
+    logoUrl: "/metco.png", // Add this logo to /public
+    start: "May 2022",
+    end: "Jul 2023",
+    description:
+      "Built predictive models (XGBoost, Logistic Regression) to anticipate lab equipment failures from 1M+ sensor logs, cutting downtime by 35%. Automated preprocessing (imputation, lag features) using Python/pandas. Delivered Power BI dashboards to QA and compliance teams for model performance and drift monitoring.",
+  },
+  {
+    company: "Accenture",
+    // href: "https://www.accenture.com/",
+    badges: ["Data Engineering", "Analytics"],
+    location: "India (Remote + Onsite)",
+    title: "Software Engineer – Data Systems",
+    logoUrl: "/acc.png", // Add this logo to /public
+    start: "May 2021",
+    end: "Apr 2022",
+    description:
+      "Developed Spark and AWS Glue pipelines processing millions of daily records. Designed ETL workflows for regulatory and financial reporting across major banking clients. Optimized SQL and integrated data from SAP HANA, Oracle, and flat files into centralized S3-based data lakes.",
+  },
+  // {
+  //   company: "Nvidia",
+  //   href: "https://nvidia.com/",
+  //   badges: [],
+  //   location: "Santa Clara, CA",
+  //   title: "Software Engineer",
+  //   logoUrl: "/nvidia.png",
+  //   start: "January 2020",
+  //   end: "April 2020",
+  //   description:
+  //     "Architected and wrote the entire MVP of the GeForce Now Cloud Gaming internal admin and A/B testing dashboard using React, Redux, TypeScript, and Python.",
+  // },
+  // {
+  //   company: "Splunk",
+  //   href: "https://splunk.com",
+  //   badges: [],
+  //   location: "San Jose, CA",
+  //   title: "Software Engineer",
+  //   logoUrl: "/splunk.svg",
+  //   start: "January 2019",
+  //   end: "April 2019",
+  //   description:
+  //     "Co-developed a prototype iOS app with another intern in Swift for the new Splunk Phantom security orchestration product (later publicly demoed and launched at .conf annual conference in Las Vegas). Implemented a realtime service for the iOS app in Django (Python) and C++; serialized data using protobufs transmitted over gRPC resulting in an approximate 500% increase in data throughput.",
+  // },
+  // {
+  //   company: "Lime",
+  //   href: "https://li.me/",
+  //   badges: [],
+  //   location: "San Francisco, CA",
+  //   title: "Software Engineer",
+  //   logoUrl: "/lime.svg",
+  //   start: "January 2018",
+  //   end: "April 2018",
+  //   description:
+  //     "Proposed and implemented an internal ruby API for sending/receiving commands to scooters over LTE networks. Developed a fully automated bike firmware update system to handle asynchronous firmware updates of over 100,000+ scooters worldwide, and provide progress reports in real-time using React, Ruby on Rails, PostgreSQL and AWS EC2 saving hundreds of developer hours.",
+  // },
+  // {
+  //   company: "Mitre Media",
+  //   href: "https://mitremedia.com/",
+  //   badges: [],
+  //   location: "Toronto, ON",
+  //   title: "Software Engineer",
+  //   logoUrl: "/mitremedia.png",
+  //   start: "May 2017",
+  //   end: "August 2017",
+  //   description:
+  //     "Designed and implemented a robust password encryption and browser cookie storage system in Ruby on Rails. Leveraged the Yahoo finance API to develop the dividend.com equity screener",
+  // },
+];
+
+const education: EducationItem[] = [
+  {
+    school: "Northeastern University",
+    degree: "Master’s in Information Systems",
+    logoUrl: "/neu.png",
+    start: "Sep 2023",
+    end: "May 2025",
+  },
+  {
+    school: "Chandigarh Engineering College",
+    degree: "B.Tech in Electronics and Communication",
+    logoUrl: "/cgc.png",
+    start: "Jun 2016",
+    end: "Apr 2020",
+  },
+  // {
+  //   school: "Wilfrid Laurier University",
+  //   href: "https://wlu.ca",
+  //   degree: "Bachelor's Degree of Business Administration (BBA)",
+  //   logoUrl: "/laurier.png",
+  //   start: "2016",
+  //   end: "2021",
+  // },
+  // {
+  //   school: "International Baccalaureate",
+  //   href: "https://ibo.org",
+  //   degree: "IB Diploma",
+  //   logoUrl: "/ib.png",
+  //   start: "2012",
+  //   end: "2016",
+  // },
+];
+
 export const DATA = {
   name: "Ronak Mishra",
   initials: "RM",
@@ -116,114 +245,8 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
     },
   },
 
-  work: [
-    {
-      company: "Metco Scientific",
-      // href: "https://www.metcoscientific.com/",
-      badges: ["Data Analytics", "ML Models", "Gen AI"],
-      location: "Mumbai, India",
-      title: "Data Analyst – Medical & Scientific Ops",
-      logoUrl: "/metco.png", // Add this logo to /public
-      start: "May 2022",
-      end: "Jul 2023",
-      description:
-        "Built predictive models (XGBoost, Logistic Regression) to anticipate lab equipment failures from 1M+ sensor logs, cutting downtime by 35%. Automated preprocessing (imputation, lag features) using Python/pandas. Delivered Power BI dashboards to QA and compliance teams for model performance and drift monitoring.",
-    },
-    {
-      company: "Accenture",
-      // href: "https://www.accenture.com/",
-      badges: ["Data Engineering", "Analytics"],
-      location: "India (Remote + Onsite)",
-      title: "Software Engineer – Data Systems",
-      logoUrl: "/acc.png", // Add this logo to /public
-      start: "May 2021",
-      end: "Apr 2022",
-      description:
-        "Developed Spark and AWS Glue pipelines processing millions of daily records. Designed ETL workflows for regulatory and financial reporting across major banking clients. Optimized SQL and integrated data from SAP HANA, Oracle, and flat files into centralized S3-based data lakes.",
-    },
-
-    // {
-    //   company: "Nvidia",
-    //   href: "https://nvidia.com/",
-    //   badges: [],
-    //   location: "Santa Clara, CA",
-    //   title: "Software Engineer",
-    //   logoUrl: "/nvidia.png",
-    //   start: "January 2020",
-    //   end: "April 2020",
-    //   description:
-    //     "Architected and wrote the entire MVP of the GeForce Now Cloud Gaming internal admin and A/B testing dashboard using React, Redux, TypeScript, and Python.",
-    // },
-    // {
-    //   company: "Splunk",
-    //   href: "https://splunk.com",
-    //   badges: [],
-    //   location: "San Jose, CA",
-    //   title: "Software Engineer",
-    //   logoUrl: "/splunk.svg",
-    //   start: "January 2019",
-    //   end: "April 2019",
-    //   description:
-    //     "Co-developed a prototype iOS app with another intern in Swift for the new Splunk Phantom security orchestration product (later publicly demoed and launched at .conf annual conference in Las Vegas). Implemented a realtime service for the iOS app in Django (Python) and C++; serialized data using protobufs transmitted over gRPC resulting in an approximate 500% increase in data throughput.",
-    // },
-    // {
-    //   company: "Lime",
-    //   href: "https://li.me/",
-    //   badges: [],
-    //   location: "San Francisco, CA",
-    //   title: "Software Engineer",
-    //   logoUrl: "/lime.svg",
-    //   start: "January 2018",
-    //   end: "April 2018",
-    //   description:
-    //     "Proposed and implemented an internal ruby API for sending/receiving commands to scooters over LTE networks. Developed a fully automated bike firmware update system to handle asynchronous firmware updates of over 100,000+ scooters worldwide, and provide progress reports in real-time using React, Ruby on Rails, PostgreSQL and AWS EC2 saving hundreds of developer hours.",
-    // },
-    // {
-    //   company: "Mitre Media",
-    //   href: "https://mitremedia.com/",
-    //   badges: [],
-    //   location: "Toronto, ON",
-    //   title: "Software Engineer",
-    //   logoUrl: "/mitremedia.png",
-    //   start: "May 2017",
-    //   end: "August 2017",
-    //   description:
-    //     "Designed and implemented a robust password encryption and browser cookie storage system in Ruby on Rails. Leveraged the Yahoo finance API to develop the dividend.com equity screener",
-    // },
-  ],
-  education: [
-    {
-      school: "Northeastern University",
-      degree: "Master’s in Information Systems",
-      logoUrl: "/neu.png",
-      start: "Sep 2023",
-      end: "May 2025",
-    },
-    {
-      school: "Chandigarh Engineering College",
-      degree: "B.Tech in Electronics and Communication",
-      logoUrl: "/cgc.png",
-      start: "Jun 2016",
-      end: "Apr 2020",
-    },
-
-    // {
-    //   school: "Wilfrid Laurier University",
-    //   href: "https://wlu.ca",
-    //   degree: "Bachelor's Degree of Business Administration (BBA)",
-    //   logoUrl: "/laurier.png",
-    //   start: "2016",
-    //   end: "2021",
-    // },
-    // {
-    //   school: "International Baccalaureate",
-    //   href: "https://ibo.org",
-    //   degree: "IB Diploma",
-    //   logoUrl: "/ib.png",
-    //   start: "2012",
-    //   end: "2016",
-    // },
-  ],
+  work,
+  education,
   projects: [
     {
       title: "Chat Collect",


### PR DESCRIPTION
## Summary
- define `WorkItem` and `EducationItem` interfaces with optional `href` and annotate resume data arrays
- update page and carousel components to consume typed resume entries and readonly project lists
- adjust BlurFade utility to satisfy strict TypeScript margin typing

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689111a9cdf48322ac9fc3c9261fd448