### PR TITLE
Use placeholder href for work experiences

### DIFF
--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -119,7 +119,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
   work: [
     {
       company: "Metco Scientific",
-      // href: "https://www.metcoscientific.com/",
+      href: "#",
       badges: ["Data Analytics", "ML Models", "Gen AI"],
       location: "Mumbai, India",
       title: "Data Analyst – Medical & Scientific Ops",
@@ -131,7 +131,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
     },
     {
       company: "Accenture",
-      // href: "https://www.accenture.com/",
+      href: "#",
       badges: ["Data Engineering", "Analytics"],
       location: "India (Remote + Onsite)",
       title: "Software Engineer – Data Systems",


### PR DESCRIPTION
## Summary
- keep `href` fields for Metco Scientific and Accenture but set them to `#` so they no longer point to external sites

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689111ac66748322a9e5d87b90430a15