### PR TITLE
Use real apostrophe in hero greeting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Page() {
                   delay={BLUR_FADE_DELAY}
                   className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none"
                   yOffset={8}
-                  text={`Hi, I&apos;m ${DATA.name.split(" ")[0]} 👋`}
+                  text={`Hi, I'm ${DATA.name.split(" ")[0]} 👋`}
                 />
                 <BlurFadeText
                   className="max-w-[600px] md:text-xl"
@@ -63,7 +63,7 @@ export default function Page() {
                   delay={BLUR_FADE_DELAY}
                   className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none"
                   yOffset={8}
-                  text={"Hi, I&apos;m " + DATA.name.split(" ")[0] + " 👋"}
+                  text={`Hi, I'm ${DATA.name.split(" ")[0]} 👋`}
                 />
 
                 {/* Line 2: Constant + Animated Typewriter Text */}


### PR DESCRIPTION
## Summary
- replace HTML entity with real apostrophe in hero greeting
- update commented hero example for consistent apostrophe usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `curl -s http://localhost:3000 | tr '<' '\n' | sed -n '20,80p'`

------
https://chatgpt.com/codex/tasks/task_e_689117b170f08322b64bdc34800b6df7