### PR TITLE
refactor: blank href for work entries

### DIFF
--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -25,7 +25,7 @@ export interface EducationItem {
 const work: WorkItem[] = [
   {
     company: "Metco Scientific",
-    // href: "https://www.metcoscientific.com/",
+    href: "",
     badges: ["Data Analytics", "ML Models", "Gen AI"],
     location: "Mumbai, India",
     title: "Data Analyst – Medical & Scientific Ops",
@@ -37,7 +37,7 @@ const work: WorkItem[] = [
   },
   {
     company: "Accenture",
-    // href: "https://www.accenture.com/",
+    href: "",
     badges: ["Data Engineering", "Analytics"],
     location: "India (Remote + Onsite)",
     title: "Software Engineer – Data Systems",
@@ -252,11 +252,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
   work: [
     {
       company: "Metco Scientific",
-
-      href: "#",
-
       href: "https://www.metcoscientific.com/",
-
       badges: ["Data Analytics", "ML Models", "Gen AI"],
       location: "Mumbai, India",
       title: "Data Analyst – Medical & Scientific Ops",
@@ -268,11 +264,7 @@ Outside of work, I enjoy building with open-source LLM stacks, exploring tools l
     },
     {
       company: "Accenture",
-
-      href: "#",
-
       href: "https://www.accenture.com/",
-
       badges: ["Data Engineering", "Analytics"],
       location: "India (Remote + Onsite)",
       title: "Software Engineer – Data Systems",


### PR DESCRIPTION
## Summary
- replace company links in resume work entries with blank href placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68911ba25a9c832299896618ff38ca59