### PR TITLE
feat: enable mobile dark theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,7 +77,7 @@ export default function RootLayout({
           fontSans.variable
         )}
       >
-        <ThemeProvider attribute="class" defaultTheme="light">
+        <ThemeProvider attribute="class" defaultTheme="system">
           <TooltipProvider delayDuration={0}>
             {children}
             <Navbar />

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,8 +1,40 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import { ThemeProviderProps } from "next-themes/dist/types";
+import { useEffect } from "react";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider {...props}>
+      <MobileDarkMode />
+      {children}
+    </NextThemesProvider>
+  );
+}
+
+function MobileDarkMode() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    const storedTheme =
+      typeof window !== "undefined" ? localStorage.getItem("theme") : null;
+
+    if (!storedTheme) {
+      const isMobile =
+        typeof navigator !== "undefined" &&
+        /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+          navigator.userAgent
+        );
+
+      const isSmallViewport =
+        typeof window !== "undefined" ? window.innerWidth < 768 : false;
+
+      if (isMobile || isSmallViewport) {
+        setTheme("dark");
+      }
+    }
+  }, [setTheme]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- default mobile devices to dark theme on initial visit
- respect system theme on desktops

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891431efdc483228bc3a0a307596e41