### PR TITLE
feat: default light theme with mobile dark override

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,7 +77,7 @@ export default function RootLayout({
           fontSans.variable
         )}
       >
-        <ThemeProvider attribute="class" defaultTheme="system">
+        <ThemeProvider attribute="class" defaultTheme="light">
           <TooltipProvider delayDuration={0}>
             {children}
             <Navbar />

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -32,6 +32,8 @@ function MobileDarkMode() {
 
       if (isMobile || isSmallViewport) {
         setTheme("dark");
+      } else {
+        setTheme("light");
       }
     }
   }, [setTheme]);


### PR DESCRIPTION
## Summary
- default desktop theme to light
- explicitly set mobile dark mode fallback

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689192daffb483228e051756e2ab5db0