### PR TITLE
feat: add desktop hover scale to project cards

### DIFF
--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -44,7 +44,7 @@ export function ProjectCard({
   return (
     <Card
       className={
-        "flex flex-col overflow-hidden border hover:shadow-lg transition-all duration-300 ease-out h-full"
+        "flex flex-col overflow-hidden border hover:shadow-lg transition-all duration-300 ease-out h-full md:hover:scale-105"
       }
     >
       <Link


### PR DESCRIPTION
## Summary
- scale project cards on hover for desktop only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891a7dd5b988322a5662524a5ede721