### PR TITLE
fix: prevent horizontal overflow on small screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,7 +71,7 @@
       @apply border-border;
     }
     body {
-      @apply bg-background text-foreground;
+      @apply bg-background text-foreground overflow-x-hidden;
     }
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,11 +103,11 @@ export default function Page() {
           </div>
         </section>
 
-        <section id="about" className="relative w-full">
+        <section id="about" className="relative w-full overflow-hidden">
           {/* 🌈 Softer Glow Background */}
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 pointer-events-none">
-            <div className="h-[180px] w-[800px] rounded-[48px] bg-gradient-to-br from-indigo-300/15 via-pink-300/10 to-purple-300/15 blur-[80px] opacity-40" />
-          </div>
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 pointer-events-none">
+              <div className="h-[180px] w-full max-w-[800px] rounded-[48px] bg-gradient-to-br from-indigo-300/15 via-pink-300/10 to-purple-300/15 blur-[80px] opacity-40" />
+            </div>
 
           {/* Section Content */}
           <div className="space-y-6">

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -52,9 +52,9 @@ export default function ContactForm() {
     //   </motion.div>
     // </section>
     <section className="w-full py-12 flex justify-center items-center">
-      <div className="relative w-full flex justify-center">
+      <div className="relative w-full flex justify-center overflow-hidden">
         {/* 🔮 Aura Glow */}
-        <div className="absolute top-1/2 left-1/2 -z-10 h-[300px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-3xl bg-fuchsia-500/30 blur-3xl opacity-60" />
+        <div className="absolute top-1/2 left-1/2 -z-10 h-[300px] w-full max-w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-3xl bg-fuchsia-500/30 blur-3xl opacity-60" />
 
         {/* 📩 Contact Form with animation */}
         <motion.div


### PR DESCRIPTION
## Summary
- hide horizontal overflow on the body element
- make glow backgrounds responsive and overflow-hidden

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689249ea539483228ad357ca203975f4