### PR TITLE
feat: add mobile slide carousel

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -111,14 +111,17 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [fade, setFade] = useState(false);
   const [isInView, setIsInView] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const touchStartX = useRef<number | null>(null);
   const carouselRef = useRef<HTMLElement | null>(null);
 
   const triggerFade = useCallback(() => {
+    // Skip fade animation on mobile where slides are used
+    if (isMobile) return;
     setFade(true);
     setTimeout(() => setFade(false), 200); // Fade out briefly
-  }, []);
+  }, [isMobile]);
 
   const next = useCallback(() => {
     triggerFade();
@@ -199,6 +202,14 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
     };
   }, [isInView, isHovered, next]);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const updateIsMobile = () => setIsMobile(mediaQuery.matches);
+    updateIsMobile();
+    mediaQuery.addEventListener("change", updateIsMobile);
+    return () => mediaQuery.removeEventListener("change", updateIsMobile);
+  }, []);
+
   return (
     <section
       ref={carouselRef}
@@ -230,27 +241,67 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
         </div>
       </div>
 
-      {/* 💫 Fade transition wrapper */}
-      <div
-        className={clsx(
-          "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 transition-opacity duration-500 ease-in-out",
-          fade ? "opacity-0" : "opacity-100"
-        )}
-      >
-        {projects.slice(index, index + itemsPerPage).map((project, idx) => (
-          <ProjectCard
-            key={idx}
-            title={project.title}
-            href={project.href}
-            description={project.description}
-            dates={project.dates}
-            tags={project.technologies}
-            image={project.image}
-            video={project.video}
-            links={project.links}
-          />
-        ))}
-      </div>
+      {isMobile ? (
+        <div className="overflow-hidden">
+          <div
+            className="flex transition-transform duration-500 ease-in-out"
+            style={{
+              transform: `translateX(-${(index / itemsPerPage) * 100}%)`,
+            }}
+          >
+            {Array.from(
+              { length: Math.ceil(projects.length / itemsPerPage) },
+              (_, pageIndex) => (
+                <div
+                  key={pageIndex}
+                  className="min-w-full grid grid-cols-1 gap-4"
+                >
+                  {projects
+                    .slice(
+                      pageIndex * itemsPerPage,
+                      pageIndex * itemsPerPage + itemsPerPage
+                    )
+                    .map((project, idx) => (
+                      <ProjectCard
+                        key={idx}
+                        title={project.title}
+                        href={project.href}
+                        description={project.description}
+                        dates={project.dates}
+                        tags={project.technologies}
+                        image={project.image}
+                        video={project.video}
+                        links={project.links}
+                      />
+                    ))}
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      ) : (
+        // 💫 Fade transition wrapper for wider screens
+        <div
+          className={clsx(
+            "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 transition-opacity duration-500 ease-in-out",
+            fade ? "opacity-0" : "opacity-100"
+          )}
+        >
+          {projects.slice(index, index + itemsPerPage).map((project, idx) => (
+            <ProjectCard
+              key={idx}
+              title={project.title}
+              href={project.href}
+              description={project.description}
+              dates={project.dates}
+              tags={project.technologies}
+              image={project.image}
+              video={project.video}
+              links={project.links}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add touch-driven slide carousel for small screens
- preserve fade transitions on larger displays

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68926b74a470832288acf6abfb56208e