### PR TITLE
feat: allow opting out of scroll preservation

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -123,50 +123,67 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
     setTimeout(() => setFade(false), 200); // Fade out briefly
   }, [isMobile]);
 
-  const next = useCallback(() => {
-    triggerFade();
-    const isMobile = window.matchMedia("(max-width: 767px)").matches;
-    const prevTop = isMobile
-      ? (carouselRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY
-      : 0;
-    const savedY = isMobile ? 0 : window.scrollY;
-    setIndex((prev) =>
-      prev + itemsPerPage >= projects.length ? 0 : prev + itemsPerPage
-    );
-    requestAnimationFrame(() => {
-      if (isMobile) {
-        const newTop =
-          (carouselRef.current?.getBoundingClientRect().top ?? 0) +
-          window.scrollY;
-        window.scrollBy(0, newTop - prevTop);
-      } else {
-        window.scrollTo(0, savedY);
+  const next = useCallback(
+    (preserveScroll: boolean = true) => {
+      triggerFade();
+      const isMobile = window.matchMedia("(max-width: 767px)").matches;
+      let prevTop = 0;
+      let savedY = 0;
+      if (preserveScroll) {
+        prevTop = isMobile
+          ? (carouselRef.current?.getBoundingClientRect().top ?? 0) +
+            window.scrollY
+          : 0;
+        savedY = isMobile ? 0 : window.scrollY;
       }
-    });
-  }, [projects.length, triggerFade]);
+      setIndex((prev) =>
+        prev + itemsPerPage >= projects.length ? 0 : prev + itemsPerPage
+      );
+      if (preserveScroll) {
+        requestAnimationFrame(() => {
+          if (isMobile) {
+            const newTop =
+              (carouselRef.current?.getBoundingClientRect().top ?? 0) +
+              window.scrollY;
+            window.scrollBy(0, newTop - prevTop);
+          } else {
+            window.scrollTo(0, savedY);
+          }
+        });
+      }
+    },
+    [projects.length, triggerFade]
+  );
 
-  const prev = () => {
+  const prev = (preserveScroll: boolean = true) => {
     triggerFade();
     const isMobile = window.matchMedia("(max-width: 767px)").matches;
-    const prevTop = isMobile
-      ? (carouselRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY
-      : 0;
-    const savedY = isMobile ? 0 : window.scrollY;
+    let prevTop = 0;
+    let savedY = 0;
+    if (preserveScroll) {
+      prevTop = isMobile
+        ? (carouselRef.current?.getBoundingClientRect().top ?? 0) +
+          window.scrollY
+        : 0;
+      savedY = isMobile ? 0 : window.scrollY;
+    }
     setIndex((prev) =>
       prev - itemsPerPage < 0
         ? Math.max(projects.length - itemsPerPage, 0)
         : prev - itemsPerPage
     );
-    requestAnimationFrame(() => {
-      if (isMobile) {
-        const newTop =
-          (carouselRef.current?.getBoundingClientRect().top ?? 0) +
-          window.scrollY;
-        window.scrollBy(0, newTop - prevTop);
-      } else {
-        window.scrollTo(0, savedY);
-      }
-    });
+    if (preserveScroll) {
+      requestAnimationFrame(() => {
+        if (isMobile) {
+          const newTop =
+            (carouselRef.current?.getBoundingClientRect().top ?? 0) +
+            window.scrollY;
+          window.scrollBy(0, newTop - prevTop);
+        } else {
+          window.scrollTo(0, savedY);
+        }
+      });
+    }
   };
 
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -212,7 +229,7 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
   useEffect(() => {
     if (isInView && !isHovered) {
       intervalRef.current = setInterval(() => {
-        next();
+        next(false);
       }, 5000);
     }
 
@@ -247,7 +264,7 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
           <Button
             variant="outline"
             size="icon"
-            onClick={prev}
+            onClick={() => prev()}
             disabled={projects.length <= itemsPerPage}
           >
             <ChevronLeft className="w-4 h-4" />
@@ -255,7 +272,7 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
           <Button
             variant="outline"
             size="icon"
-            onClick={next}
+            onClick={() => next()}
             disabled={projects.length <= itemsPerPage}
           >
             <ChevronRight className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- allow carousel navigation to skip scroll correction via optional flag
- prevent auto-rotation from adjusting page scroll

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch Inter from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_6892717d8cb88322bbde20fa357dff81