### PR TITLE
fix: keep carousel page heights

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -299,7 +299,7 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
 
       <div className="overflow-hidden">
         <div
-          className={`flex ${disableTransition ? "" : "transition-transform duration-500 ease-in-out"}`}
+          className={`flex items-start ${disableTransition ? "" : "transition-transform duration-500 ease-in-out"}`}
           style={{
             transform: `translateX(-${(index / itemsPerPage) * 100}%)`,
           }}


### PR DESCRIPTION
## Summary
- ensure ProjectCarousel pages retain independent heights by adding Tailwind `items-start`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_6892c39ac19c83228fb3cf1608528c87