### PR TITLE
fix: ensure carousel page refs return void

### DIFF
--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -336,7 +336,9 @@ export default function ProjectCarousel({ projects }: CarouselProps) {
             return (
               <div
                 key={pageIndex}
-                ref={(el) => (pageRefs.current[pageIndex] = el)}
+                ref={(el) => {
+                  pageRefs.current[pageIndex] = el;
+                }}
                 className="min-w-full grid grid-cols-1 md:grid-cols-2 gap-4"
               >
                 {filled.map((project, idx) =>


### PR DESCRIPTION
## Summary
- fix ProjectCarousel ref callback to return void and satisfy React types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_6892c87febf08322a3ebded36e544606