### PR TITLE
fix: improve mobile resume and skills layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,7 +125,9 @@ export default function Page() {
         <section id="work">
           <div className="flex min-h-0 flex-col gap-y-3">
             <BlurFade delay={BLUR_FADE_DELAY * 5}>
-              <h2 className="text-xl font-bold">Work Experience</h2>
+              <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">
+                Work Experience
+              </h2>
             </BlurFade>
             {DATA.work.map((work: WorkItem, id) => (
               <BlurFade key={work.company} delay={BLUR_FADE_DELAY * 6 + id * 0.05}>
@@ -147,7 +149,9 @@ export default function Page() {
         <section id="education">
           <div className="flex min-h-0 flex-col gap-y-3">
             <BlurFade delay={BLUR_FADE_DELAY * 7}>
-              <h2 className="text-xl font-bold">Education</h2>
+              <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">
+                Education
+              </h2>
             </BlurFade>
             {DATA.education.map((education: EducationItem, id) => (
               <BlurFade key={education.school} delay={BLUR_FADE_DELAY * 8 + id * 0.05}>
@@ -167,9 +171,11 @@ export default function Page() {
         <section id="skills">
           <div className="flex min-h-0 flex-col gap-y-3">
             <BlurFade delay={BLUR_FADE_DELAY * 9}>
-              <h2 className="text-xl font-bold">Skills</h2>
+              <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">
+                Skills
+              </h2>
             </BlurFade>
-            <div className="flex flex-wrap gap-1">
+            <div className="flex flex-wrap justify-center gap-2 sm:justify-start sm:gap-1">
               {DATA.skills.map((skill, id) => (
                 <BlurFade key={skill} delay={BLUR_FADE_DELAY * 10 + id * 0.05}>
                   <Badge key={skill}>{skill}</Badge>

--- a/src/components/resume-card.tsx
+++ b/src/components/resume-card.tsx
@@ -154,20 +154,20 @@ export const ResumeCard = ({
   };
 
   const cardContent = (
-    <Card className="flex">
+    <Card className="flex items-start sm:items-center">
       <div className="flex-none">
-        <Avatar className="border size-12 m-auto bg-muted-background dark:bg-foreground">
+        <Avatar className="border size-12 mt-1 sm:m-auto bg-muted-background dark:bg-foreground">
           <AvatarImage src={logoUrl} alt={altText} className="object-contain" />
           <AvatarFallback>{altText[0]}</AvatarFallback>
         </Avatar>
       </div>
-      <div className="flex-grow ml-4 items-center flex-col group">
-        <CardHeader>
-          <div className="flex items-center justify-between gap-x-2 text-base">
-            <h3 className="inline-flex items-center justify-center font-semibold leading-none text-xs sm:text-sm">
+      <div className="flex-grow ml-4 group">
+        <CardHeader className="p-0">
+          <div className="flex w-full items-start justify-between gap-x-2">
+            <h3 className="flex flex-1 items-center font-semibold leading-none text-xs sm:text-sm">
               {title}
               {badges && (
-                <span className="inline-flex gap-x-1">
+                <span className="hidden sm:inline-flex gap-x-1 ml-1">
                   {badges.map((badge, index) => (
                     <Badge
                       variant="secondary"
@@ -190,7 +190,27 @@ export const ResumeCard = ({
               {period}
             </div>
           </div>
-          {subtitle && <div className="font-sans text-xs">{subtitle}</div>}
+          {subtitle && (
+            <div className="mt-1 font-sans text-xs hidden sm:block">{subtitle}</div>
+          )}
+          {subtitle && (
+            <div className="mt-1 font-sans text-xs flex flex-wrap items-center gap-1 sm:hidden">
+              {subtitle}
+              {badges && (
+                <span className="inline-flex gap-1">
+                  {badges.map((badge, index) => (
+                    <Badge
+                      variant="secondary"
+                      className="align-middle text-xs"
+                      key={index}
+                    >
+                      {badge}
+                    </Badge>
+                  ))}
+                </span>
+              )}
+            </div>
+          )}
         </CardHeader>
         {description && (
           <motion.div


### PR DESCRIPTION
## Summary
- refine resume cards so company, role, and tags align cleanly on mobile
- add mobile-only spacing for section headers and better skill badge wrapping

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892cd5547e883228c9bae24df0ad90e