### PR TITLE
feat: add structured skill groups

### DIFF
--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,73 @@
+export interface SkillGroup {
+  title: string;
+  icon: string;
+  items: readonly string[];
+}
+
+export const SKILL_GROUPS: SkillGroup[] = [
+  {
+    title: "Data Engineering",
+    icon: "🛠️",
+    items: [
+      "Python",
+      "SQL",
+      "PySpark",
+      "Apache Spark",
+      "Databricks",
+      "Airflow",
+      "dbt",
+    ],
+  },
+  {
+    title: "Cloud Platforms & Storage",
+    icon: "☁️",
+    items: [
+      "AWS S3",
+      "AWS Glue",
+      "AWS Redshift",
+      "AWS Lambda",
+      "AWS Athena",
+      "AWS Kinesis",
+      "AWS EventBridge",
+      "GCP BigQuery",
+      "Azure Data Factory",
+      "Azure Synapse",
+    ],
+  },
+  {
+    title: "Data Warehousing & Modeling",
+    icon: "🗄️",
+    items: [
+      "Snowflake",
+      "Delta Lake",
+      "Parquet",
+    ],
+  },
+  {
+    title: "Analytics & Visualization",
+    icon: "📊",
+    items: [
+      "Power BI",
+      "Tableau",
+      "AWS QuickSight",
+    ],
+  },
+  {
+    title: "DevOps & CI/CD",
+    icon: "⚙️",
+    items: [
+      "Git",
+      "Docker",
+      "GitHub Actions",
+    ],
+  },
+  {
+    title: "GenAI & Applied ML",
+    icon: "🤖",
+    items: [
+      "LangChain",
+      "RAG Pipelines",
+      "LLMOps",
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add SkillGroup interface and grouped skill data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966a9a5cfc8322bdc40877d7f26f05