### PR TITLE
feat: add skills carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,12 +11,12 @@ import BackgroundNetwork from "@/components/BackgroundNetwork";
 import { Typewriter } from "react-simple-typewriter";
 import { ResumeCard } from "@/components/resume-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { DATA, type WorkItem, type EducationItem } from "@/data/resume";
 import Link from "next/link";
 import Markdown from "react-markdown";
 // for contact
 import ContactForm from "@/components/ContactForm";
+import SkillsCarousel from "@/components/SkillsCarousel";
 
 // for contact
 const BLUR_FADE_DELAY = 0.04;
@@ -166,20 +166,7 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section id="skills">
-          <div className="flex min-h-0 flex-col gap-y-3">
-            <BlurFade delay={BLUR_FADE_DELAY * 9}>
-              <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">Skills</h2>
-            </BlurFade>
-            <div className="flex flex-wrap justify-center gap-2 sm:justify-start sm:gap-1">
-              {DATA.skills.map((skill, id) => (
-                <BlurFade key={skill} delay={BLUR_FADE_DELAY * 10 + id * 0.05}>
-                  <Badge key={skill}>{skill}</Badge>
-                </BlurFade>
-              ))}
-            </div>
-          </div>
-        </section>
+        <SkillsCarousel />
 
         {/* <section id="projects">
         <div className="space-y-12 w-full py-12">

--- a/src/components/SkillsCarousel.tsx
+++ b/src/components/SkillsCarousel.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import BlurFade from "@/components/magicui/blur-fade";
+import { Badge } from "@/components/ui/badge";
+import { DATA } from "@/data/resume";
+
+const BLUR_FADE_DELAY = 0.04;
+
+export default function SkillsCarousel() {
+  return (
+    <section id="skills">
+      <div className="flex min-h-0 flex-col gap-y-3">
+        <BlurFade delay={BLUR_FADE_DELAY * 9}>
+          <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">Skills</h2>
+        </BlurFade>
+        <div className="overflow-x-auto">
+          <div className="flex w-max gap-2 sm:gap-1">
+            {DATA.skills.map((skill, id) => (
+              <BlurFade key={skill} delay={BLUR_FADE_DELAY * 10 + id * 0.05}>
+                <Badge>{skill}</Badge>
+              </BlurFade>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate SkillsCarousel component and remove inline skills grid
- create SkillsCarousel to display skills badges in a horizontal scroll

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966a9c641c8322ad92e5d6a7114155