### PR TITLE
Add skills carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,10 +11,10 @@ import BackgroundNetwork from "@/components/BackgroundNetwork";
 import { Typewriter } from "react-simple-typewriter";
 import { ResumeCard } from "@/components/resume-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { DATA, type WorkItem, type EducationItem } from "@/data/resume";
 import Link from "next/link";
 import Markdown from "react-markdown";
+import SkillsCarousel from "@/components/skills-carousel";
 // for contact
 import ContactForm from "@/components/ContactForm";
 
@@ -171,13 +171,9 @@ export default function Page() {
             <BlurFade delay={BLUR_FADE_DELAY * 9}>
               <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">Skills</h2>
             </BlurFade>
-            <div className="flex flex-wrap justify-center gap-2 sm:justify-start sm:gap-1">
-              {DATA.skills.map((skill, id) => (
-                <BlurFade key={skill} delay={BLUR_FADE_DELAY * 10 + id * 0.05}>
-                  <Badge key={skill}>{skill}</Badge>
-                </BlurFade>
-              ))}
-            </div>
+            <BlurFade delay={BLUR_FADE_DELAY * 10}>
+              <SkillsCarousel />
+            </BlurFade>
           </div>
         </section>
 

--- a/src/components/skills-carousel.tsx
+++ b/src/components/skills-carousel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { SKILL_GROUPS } from "@/data/skills";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export default function SkillsCarousel() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isPaused = useRef(false);
+  const isDragging = useRef(false);
+  const startX = useRef(0);
+  const scrollStart = useRef(0);
+  const cardWidth = useRef(0);
+
+  const pause = () => {
+    isPaused.current = true;
+  };
+  const play = () => {
+    isPaused.current = false;
+  };
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const firstCard = container.querySelector<HTMLElement>(".skill-card");
+    if (firstCard) {
+      const style = window.getComputedStyle(firstCard);
+      cardWidth.current =
+        firstCard.offsetWidth + parseInt(style.marginRight || "0");
+    }
+    const step = () => {
+      if (!containerRef.current) return;
+      if (!isPaused.current) {
+        containerRef.current.scrollLeft += 0.5;
+        const maxScroll = containerRef.current.scrollWidth / 2;
+        if (containerRef.current.scrollLeft >= maxScroll) {
+          containerRef.current.scrollLeft -= maxScroll;
+        }
+      }
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, []);
+
+  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    isDragging.current = true;
+    startX.current = e.clientX;
+    scrollStart.current = containerRef.current?.scrollLeft || 0;
+    pause();
+  };
+
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isDragging.current || !containerRef.current) return;
+    const dx = e.clientX - startX.current;
+    containerRef.current.scrollLeft = scrollStart.current - dx;
+  };
+
+  const endDrag = () => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    play();
+  };
+
+  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    isDragging.current = true;
+    startX.current = e.touches[0].clientX;
+    scrollStart.current = containerRef.current?.scrollLeft || 0;
+    pause();
+  };
+
+  const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (!isDragging.current || !containerRef.current) return;
+    const dx = e.touches[0].clientX - startX.current;
+    containerRef.current.scrollLeft = scrollStart.current - dx;
+  };
+
+  const onTouchEnd = () => {
+    if (!isDragging.current) return;
+    isDragging.current = false;
+    play();
+  };
+
+  const scrollByCard = (direction: number) => {
+    const container = containerRef.current;
+    if (!container) return;
+    pause();
+    container.scrollBy({ left: direction * cardWidth.current, behavior: "smooth" });
+    setTimeout(() => play(), 300);
+  };
+
+  const duplicated = [...SKILL_GROUPS, ...SKILL_GROUPS];
+
+  return (
+    <div className="relative" aria-label="Skills carousel">
+      <div className="absolute right-0 top-0 flex gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-full"
+          aria-label="Previous"
+          onClick={() => scrollByCard(-1)}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-full"
+          aria-label="Next"
+          onClick={() => scrollByCard(1)}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+      <div
+        ref={containerRef}
+        className="overflow-hidden cursor-grab"
+        onMouseEnter={pause}
+        onMouseLeave={() => {
+          if (!isDragging.current) play();
+        }}
+        onFocusCapture={pause}
+        onBlurCapture={play}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={endDrag}
+        onMouseLeaveCapture={endDrag}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
+        <div className="flex">
+          {duplicated.map((group, idx) => (
+            <div
+              key={idx}
+              className="skill-card mr-4 shrink-0 w-64 rounded-lg bg-secondary p-4 flex flex-col gap-2"
+            >
+              <h3 className="text-sm font-medium">
+                <span className="mr-2">{group.emoji}</span>
+                {group.title}
+              </h3>
+              <div className="flex flex-wrap gap-1">
+                {group.skills.map((skill) => (
+                  <Badge key={skill} variant="secondary">
+                    {skill}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,63 @@
+export interface SkillGroup {
+  title: string;
+  emoji: string;
+  skills: readonly string[];
+}
+
+export const SKILL_GROUPS: readonly SkillGroup[] = [
+  {
+    title: "Data Engineering",
+    emoji: "🛠️",
+    skills: [
+      "Python",
+      "SQL",
+      "PySpark",
+      "Apache Spark",
+      "Databricks",
+      "Airflow",
+      "dbt",
+    ],
+  },
+  {
+    title: "Cloud Platforms",
+    emoji: "☁️",
+    skills: [
+      "AWS S3",
+      "AWS Glue",
+      "AWS Redshift",
+      "AWS Lambda",
+      "AWS Athena",
+      "AWS Kinesis",
+      "AWS EventBridge",
+      "Azure ADF",
+      "Azure Synapse",
+      "GCP BigQuery",
+    ],
+  },
+  {
+    title: "Warehousing & Tables",
+    emoji: "📦",
+    skills: [
+      "Snowflake",
+      "Redshift",
+      "Synapse",
+      "Delta Lake",
+      "Parquet",
+    ],
+  },
+  {
+    title: "GenAI & NLP",
+    emoji: "🤖",
+    skills: ["LangChain", "RAG", "LLMs", "Vector DBs"],
+  },
+  {
+    title: "Analytics & BI",
+    emoji: "📊",
+    skills: ["Power BI", "Tableau", "QuickSight"],
+  },
+  {
+    title: "DevOps & CI/CD",
+    emoji: "⚙️",
+    skills: ["Git", "Docker", "GitHub Actions"],
+  },
+] as const;


### PR DESCRIPTION
## Summary
- configure skill groups for carousel display
- build custom autoplaying skill carousel with drag and button controls
- replace static skills list on homepage with new carousel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966f3219988322ba225668ccd96200