### PR TITLE
Fix drag end handling in skills carousel

### DIFF
--- a/src/components/skills-carousel.tsx
+++ b/src/components/skills-carousel.tsx
@@ -119,14 +119,17 @@ export default function SkillsCarousel() {
         className="overflow-hidden cursor-grab"
         onMouseEnter={pause}
         onMouseLeave={() => {
-          if (!isDragging.current) play();
+          if (isDragging.current) {
+            endDrag();
+          } else {
+            play();
+          }
         }}
         onFocusCapture={pause}
         onBlurCapture={play}
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={endDrag}
-        onMouseLeaveCapture={endDrag}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}


### PR DESCRIPTION
## Summary
- Clean up mouse leave handler on skills carousel to avoid unsupported capture event

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689670f8838083229ef681c238c06958