### PR TITLE
Revamp skills grid styling

### DIFF
--- a/src/components/skills-grid.tsx
+++ b/src/components/skills-grid.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { SKILLS, type Role } from "@/data/skills";
 import { cn } from "@/lib/utils";
 
 const ROLE_TABS: readonly (Role | "All")[] = [
   "All",
-  "Data Analyst",
-  "Data Engineer",
-  "AI Engineer",
+  "Data Engineering",
+  "Data Analytics",
+  "AI Engineering",
 ] as const;
+
+const HIGHLIGHT_COLOR = "#FFB100";
 
 export default function SkillsGrid() {
   const [role, setRole] = useState<(typeof ROLE_TABS)[number]>("All");
@@ -24,17 +26,18 @@ export default function SkillsGrid() {
             onClick={() => setRole(r)}
             aria-pressed={role === r}
             className={cn(
-              "px-3 py-1 rounded-full text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "rounded-full px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--highlight)]",
               role === r
-                ? "bg-primary text-primary-foreground"
-                : "bg-muted text-muted-foreground hover:bg-muted/80"
+                ? "bg-[var(--highlight)] text-black"
+                : "bg-black text-white hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80",
             )}
+            style={{ "--highlight": HIGHLIGHT_COLOR } as CSSProperties}
           >
             {r}
           </button>
         ))}
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+      <div className="flex flex-wrap justify-center gap-3">
         {SKILLS.map((skill) => {
           const active = role === "All" || skill.roles.includes(role as Role);
           return (
@@ -42,15 +45,31 @@ export default function SkillsGrid() {
               key={skill.id}
               tabIndex={0}
               className={cn(
-                "flex flex-col items-center justify-center gap-2 rounded-lg p-4 text-sm font-medium transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                "hover:scale-105",
-                active
-                  ? "bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/50 shadow-sm"
-                  : "border border-muted bg-muted text-muted-foreground opacity-60"
+                "flex h-12 items-center gap-2 rounded-full px-4 text-sm font-medium transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--highlight)]",
+                "hover:scale-105 shadow-sm",
+                "bg-black text-white dark:bg-white dark:text-black",
               )}
+              style={{ "--highlight": HIGHLIGHT_COLOR } as CSSProperties}
             >
-              <skill.icon className="h-6 w-6" aria-hidden="true" />
-              {skill.label}
+              <skill.icon
+                className={cn(
+                  "h-5 w-5 transition-colors",
+                  role === "All"
+                    ? ""
+                    : active
+                      ? "text-[var(--highlight)]"
+                      : "text-gray-400 opacity-50",
+                )}
+                aria-hidden="true"
+              />
+              <span
+                className={cn(
+                  "transition-colors",
+                  role === "All" ? "" : active ? "" : "text-gray-400 opacity-50",
+                )}
+              >
+                {skill.label}
+              </span>
             </div>
           );
         })}

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -22,7 +22,7 @@ import {
   AreaChart,
 } from "lucide-react";
 
-export type Role = "Data Analyst" | "Data Engineer" | "AI Engineer";
+export type Role = "Data Analytics" | "Data Engineering" | "AI Engineering";
 
 export interface Skill {
   id: string;
@@ -36,13 +36,13 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "python",
     label: "Python",
-    roles: ["Data Analyst", "Data Engineer", "AI Engineer"],
+    roles: ["Data Analytics", "Data Engineering", "AI Engineering"],
     icon: Code,
   },
   {
     id: "sql",
     label: "SQL",
-    roles: ["Data Analyst", "Data Engineer", "AI Engineer"],
+    roles: ["Data Analytics", "Data Engineering", "AI Engineering"],
     icon: Database,
   },
 
@@ -50,31 +50,31 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "pyspark",
     label: "PySpark",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Flame,
   },
   {
     id: "apache-spark",
     label: "Apache Spark",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Flame,
   },
   {
     id: "databricks",
     label: "Databricks",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Layers,
   },
   {
     id: "airflow",
     label: "Airflow",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Wind,
   },
   {
     id: "dbt",
     label: "dbt",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Box,
   },
 
@@ -82,19 +82,19 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "aws",
     label: "AWS",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Cloud,
   },
   {
     id: "gcp",
     label: "GCP",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Cloud,
   },
   {
     id: "azure",
     label: "Azure",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Cloud,
   },
 
@@ -102,31 +102,31 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "snowflake",
     label: "Snowflake",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Snowflake,
   },
   {
     id: "redshift",
     label: "Redshift",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Archive,
   },
   {
     id: "synapse",
     label: "Synapse",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Network,
   },
   {
     id: "delta-lake",
     label: "Delta Lake",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: Triangle,
   },
   {
     id: "parquet",
     label: "Parquet",
-    roles: ["Data Engineer"],
+    roles: ["Data Engineering"],
     icon: FileText,
   },
 
@@ -134,25 +134,25 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "langchain",
     label: "LangChain",
-    roles: ["AI Engineer"],
+    roles: ["AI Engineering"],
     icon: Link2,
   },
   {
     id: "rag",
     label: "RAG",
-    roles: ["AI Engineer"],
+    roles: ["AI Engineering"],
     icon: BookOpen,
   },
   {
     id: "huggingface",
     label: "HuggingFace",
-    roles: ["AI Engineer"],
+    roles: ["AI Engineering"],
     icon: Smile,
   },
   {
     id: "scikit-learn",
     label: "scikit-learn",
-    roles: ["AI Engineer"],
+    roles: ["AI Engineering"],
     icon: Brain,
   },
 
@@ -160,19 +160,19 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "mysql",
     label: "MySQL",
-    roles: ["Data Analyst", "Data Engineer"],
+    roles: ["Data Analytics", "Data Engineering"],
     icon: Database,
   },
   {
     id: "postgresql",
     label: "PostgreSQL",
-    roles: ["Data Analyst", "Data Engineer"],
+    roles: ["Data Analytics", "Data Engineering"],
     icon: Database,
   },
   {
     id: "mongodb",
     label: "MongoDB",
-    roles: ["Data Analyst", "Data Engineer"],
+    roles: ["Data Analytics", "Data Engineering"],
     icon: Leaf,
   },
 
@@ -180,19 +180,19 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "power-bi",
     label: "Power BI",
-    roles: ["Data Analyst"],
+    roles: ["Data Analytics"],
     icon: BarChart3,
   },
   {
     id: "tableau",
     label: "Tableau",
-    roles: ["Data Analyst"],
+    roles: ["Data Analytics"],
     icon: TableIcon,
   },
   {
     id: "quicksight",
     label: "QuickSight",
-    roles: ["Data Analyst"],
+    roles: ["Data Analytics"],
     icon: AreaChart,
   },
 ] as const;


### PR DESCRIPTION
## Summary
- convert square skill tiles to capsule-style with black/white base and amber highlight accents
- update skill filters to Data Engineering, Data Analytics and AI Engineering with matching highlight state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68969941ac2c8322b522fc1b61c32bdf