### PR TITLE
Refine skills section visuals

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -166,14 +166,15 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section id="skills">
-          <div className="flex min-h-0 flex-col gap-y-3">
+        <section id="skills" className="relative w-full py-20">
+          <div className="absolute inset-0 -z-10">
+            <div className="absolute inset-0 bg-gradient-to-br from-purple-500/20 via-pink-500/10 to-indigo-500/20 blur-3xl opacity-60" />
+          </div>
+          <div className="w-full max-w-5xl mx-auto flex min-h-0 flex-col gap-y-3">
             <BlurFade delay={BLUR_FADE_DELAY * 9}>
               <h2 className="text-xl font-bold mt-8 mb-4 sm:mt-0 sm:mb-0">Skills</h2>
             </BlurFade>
-            <BlurFade delay={BLUR_FADE_DELAY * 10}>
-              <SkillsGrid />
-            </BlurFade>
+            <SkillsGrid />
           </div>
         </section>
 

--- a/src/components/skills-grid.tsx
+++ b/src/components/skills-grid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { useState, useRef, type CSSProperties } from "react";
+import { AnimatePresence, motion, useInView, useReducedMotion } from "framer-motion";
 
 import { SKILLS, type Role } from "@/data/skills";
 import { cn } from "@/lib/utils";
@@ -13,34 +13,31 @@ const ROLE_TABS: readonly (Role | "All")[] = [
   "AI Engineering",
 ] as const;
 
-// Soft pink accent used throughout the site
-const HIGHLIGHT_COLOR = "rgba(255,110,199,0.7)";
-
-// Staggered animation with blur-to-clear effect
-const container = {
-  hidden: {},
-  show: {
-    transition: {
-      staggerChildren: 0.06,
-    },
-  },
-};
-
-const item = {
-  hidden: { opacity: 0, y: 12, filter: "blur(4px)" },
-  show: { opacity: 1, y: 0, filter: "blur(0px)" },
-  exit: { opacity: 0, y: 12, filter: "blur(4px)" },
-};
+// Subtle pink-violet accent
+const HIGHLIGHT_COLOR = "rgba(255,120,255,0.7)";
 
 export default function SkillsGrid() {
   const [role, setRole] = useState<(typeof ROLE_TABS)[number]>("All");
+  const prefersReducedMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(containerRef, { once: true });
 
   const skills =
     role === "All" ? SKILLS : SKILLS.filter((s) => s.roles.includes(role as Role));
 
   return (
-    <div>
-      <div className="mb-6 flex gap-2 overflow-x-auto pb-2 pt-1 sm:justify-center">
+    <motion.div
+      ref={containerRef}
+      initial={{ opacity: 0, y: prefersReducedMotion ? 0 : 10 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+    >
+      <motion.div
+        initial={{ opacity: 0, y: prefersReducedMotion ? 0 : 8 }}
+        animate={isInView ? { opacity: 1, y: 0 } : {}}
+        transition={{ delay: 0.08, duration: 0.2, ease: "easeOut" }}
+        className="mb-6 flex gap-2 overflow-x-auto pb-2 pt-1 sm:justify-center"
+      >
         {ROLE_TABS.map((r) => (
           <button
             key={r}
@@ -50,43 +47,64 @@ export default function SkillsGrid() {
             className={cn(
               "flex-shrink-0 rounded-full px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--highlight)]",
               role === r
-                ? "bg-[var(--highlight)] text-black shadow-[0_0_8px_var(--highlight)]"
-                : "bg-white text-black hover:shadow-[0_0_8px_var(--highlight)] dark:bg-black dark:text-white",
+                ? "bg-black text-white ring-1 ring-[var(--highlight)] shadow-[0_0_6px_var(--highlight)] dark:bg-white dark:text-black"
+                : "border border-black text-black hover:shadow-[0_0_6px_var(--highlight)] dark:border-white dark:text-white",
             )}
             style={{ "--highlight": HIGHLIGHT_COLOR } as CSSProperties}
           >
             {r}
           </button>
         ))}
-      </div>
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={role}
-          variants={container}
-          initial="hidden"
-          animate="show"
-          exit="hidden"
-          className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4"
-        >
-          {skills.map((skill) => (
+      </motion.div>
+      <motion.div
+        className="grid grid-cols-2 gap-2 justify-items-center sm:grid-cols-3 md:grid-cols-4"
+      >
+        <AnimatePresence initial={false} mode="sync">
+          {skills.map((skill, i) => (
             <motion.div
               key={skill.id}
-              variants={item}
+              initial={{
+                opacity: 0,
+                y: prefersReducedMotion ? 0 : 8,
+                filter: prefersReducedMotion ? "none" : "blur(4px)",
+              }}
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              exit={{
+                opacity: 0,
+                y: prefersReducedMotion ? 0 : 8,
+                filter: prefersReducedMotion ? "none" : "blur(4px)",
+              }}
+              transition={{
+                delay: 0.2 + i * 0.06,
+                duration: 0.2,
+                ease: "easeOut",
+              }}
               className={cn(
-                "flex h-10 w-full items-center justify-center gap-2 rounded-full px-3 transition-shadow",
-                role === "All"
-                  ? "bg-white text-black hover:shadow-[0_0_8px_var(--highlight)] dark:bg-black dark:text-white"
-                  : "bg-[var(--highlight)] text-black shadow-[0_0_8px_var(--highlight)]",
+                "flex h-10 w-full items-center justify-center gap-2 rounded-full px-3 transition-shadow bg-black text-white dark:bg-white dark:text-black",
+                role !== "All" && "shadow-[0_0_6px_var(--highlight)]",
               )}
               style={{ "--highlight": HIGHLIGHT_COLOR } as CSSProperties}
             >
-              <skill.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-              <span className="text-sm font-medium">{skill.label}</span>
+              <skill.icon
+                className={cn(
+                  "h-4 w-4 flex-shrink-0",
+                  role !== "All" && "text-[var(--highlight)]",
+                )}
+                aria-hidden="true"
+              />
+              <span
+                className={cn(
+                  "text-sm font-medium",
+                  role !== "All" && "text-[var(--highlight)]",
+                )}
+              >
+                {skill.label}
+              </span>
             </motion.div>
           ))}
-        </motion.div>
-      </AnimatePresence>
-    </div>
+        </AnimatePresence>
+      </motion.div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Implement pink-violet glow accent for skills filtering
- Animate skills grid on viewport entry with staggered blur-to-sharp effects
- Match skills section background to projects gradient canvas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896a328e5148322b4a3c4eec219c699