### PR TITLE
Rename AI category and round skill chips

### DIFF
--- a/src/components/skills-grid.tsx
+++ b/src/components/skills-grid.tsx
@@ -10,7 +10,7 @@ const ROLE_TABS: readonly (Role | "All")[] = [
   "All",
   "Data Engineering",
   "Data Analytics",
-  "AI Engineering",
+  "AI",
 ] as const;
 
 // Subtle pink-violet accent
@@ -80,7 +80,7 @@ export default function SkillsGrid() {
                 ease: "easeOut",
               }}
               className={cn(
-                "flex flex-col items-center justify-center gap-1 w-24 h-24 text-center rounded-md border border-black text-xs text-black transition-shadow dark:border-white dark:text-white",
+                "flex flex-col items-center justify-center gap-1 w-24 h-24 text-center rounded-full border border-black text-xs text-black transition-shadow dark:border-white dark:text-white",
               )}
             >
               <skill.icon

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -22,7 +22,7 @@ import {
   AreaChart,
 } from "lucide-react";
 
-export type Role = "Data Analytics" | "Data Engineering" | "AI Engineering";
+export type Role = "Data Analytics" | "Data Engineering" | "AI";
 
 export interface Skill {
   id: string;
@@ -36,13 +36,13 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "python",
     label: "Python",
-    roles: ["Data Analytics", "Data Engineering", "AI Engineering"],
+    roles: ["Data Analytics", "Data Engineering", "AI"],
     icon: Code,
   },
   {
     id: "sql",
     label: "SQL",
-    roles: ["Data Analytics", "Data Engineering", "AI Engineering"],
+    roles: ["Data Analytics", "Data Engineering", "AI"],
     icon: Database,
   },
 
@@ -134,25 +134,25 @@ export const SKILLS: readonly Skill[] = [
   {
     id: "langchain",
     label: "LangChain",
-    roles: ["AI Engineering"],
+    roles: ["AI"],
     icon: Link2,
   },
   {
     id: "rag",
     label: "RAG",
-    roles: ["AI Engineering"],
+    roles: ["AI"],
     icon: BookOpen,
   },
   {
     id: "huggingface",
     label: "HuggingFace",
-    roles: ["AI Engineering"],
+    roles: ["AI"],
     icon: Smile,
   },
   {
     id: "scikit-learn",
     label: "scikit-learn",
-    roles: ["AI Engineering"],
+    roles: ["AI"],
     icon: Brain,
   },
 


### PR DESCRIPTION
## Summary
- rename AI Engineering category to AI
- round skill chips to match category pills

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896aab2b17c83228739c0b79a4fb6ad